### PR TITLE
Local grader task 1B: pass in dict instead of DataFrame

### DIFF
--- a/local_grader.py
+++ b/local_grader.py
@@ -45,9 +45,9 @@ class T1A(autograder.question.Question):
 
 class T1B(autograder.question.Question):
     def score_question(self, submission):
-        data = pandas.DataFrame({
+        data = {
             'a': [1, 2, 3],
-        })
+        }
 
         result = submission.__all__.split_dict_data(data, 0.5)
         if (self.check_not_implemented(result)):


### PR DESCRIPTION
Currently, the local grader script tries to pass in a DataFrame, but the assignment says that the function takes in dicts, and the autograder only passes in valid dicts, so this seems to just be a bug in the local grader. This PR fixes it to pass in a dict, so it properly tests the function.
